### PR TITLE
fix s3, not all storages have "path" attribute

### DIFF
--- a/djangocms_picture/models.py
+++ b/djangocms_picture/models.py
@@ -54,8 +54,8 @@ class Picture(CMSPlugin):
             # added if, because it raised attribute error when file wasn't
             # defined.
             try:
-                return u"%s" % os.path.basename(self.image.path)
-            except:
+                return u"%s" % os.path.basename(self.image.name)
+            except AttributeError:
                 pass
         return u"<empty>"
 


### PR DESCRIPTION
When the current storage was a type that did not have a path attribute (S3BotoStorage from django_storage, for example) the bare except was swallowing the error and just returning `<empty>`, even though it does have an image. `Image.name` comes from Django so seems we can rely on it being there. I believe the output is identical.

Not really sure what the `except` is supporting, but `AttributeError` seems the only conceivable thing.

This is the error it caused when I tried to upload an image with `DEFAULT_FILE_STORAGE = 'storages.backends.s3boto.S3BotoStorage'`

```
 File "/app/.heroku/python/lib/python2.7/site-packages/django/core/handlers/base.py", line 112, in get_response
   response = wrapped_callback(request, *callback_args, **callback_kwargs)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/utils/decorators.py", line 99, in _wrapped_view
   response = view_func(request, *args, **kwargs)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/views/decorators/cache.py", line 52, in _wrapped_view_func
   response = view_func(request, *args, **kwargs)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/contrib/admin/sites.py", line 198, in inner
   return view(request, *args, **kwargs)

 File "/app/.heroku/python/lib/python2.7/site-packages/cms/admin/pageadmin.py", line 1485, in edit_plugin
   return super(PageAdmin, self).edit_plugin(*args, **kwargs)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/views/decorators/clickjacking.py", line 41, in wrapped_view
   resp = view_func(*args, **kwargs)

 File "/app/.heroku/python/lib/python2.7/site-packages/cms/admin/placeholderadmin.py", line 389, in edit_plugin
   response = plugin_admin.add_view(request)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/utils/decorators.py", line 29, in _wrapper
   return bound_func(*args, **kwargs)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/utils/decorators.py", line 99, in _wrapped_view
   response = view_func(request, *args, **kwargs)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/utils/decorators.py", line 25, in bound_func
   return func(self, *args2, **kwargs2)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/db/transaction.py", line 371, in inner
   return func(*args, **kwargs)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/contrib/admin/options.py", line 1134, in add_view
   return self.response_add(request, new_object)

 File "/app/.heroku/python/lib/python2.7/site-packages/cms/plugin_base.py", line 221, in response_add
   return super(CMSPluginBase, self).response_add(request, obj, **kwargs)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/contrib/admin/options.py", line 930, in response_add
   'obj': escapejs(obj)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/utils/functional.py", line 203, in wrapper
   return func(*args, **kwargs)

 File "/app/.heroku/python/lib/python2.7/site-packages/django/utils/html.py", line 61, in escapejs
   return mark_safe(force_text(value).translate(_js_escapes))

TypeError: expected a character buffer object


```
