### PR TITLE
Adds optional style to any picture

### DIFF
--- a/djangocms_picture/migrations_django/0002_picture_style.py
+++ b/djangocms_picture/migrations_django/0002_picture_style.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_picture', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='picture',
+            name='style',
+            field=models.CharField(max_length=255, help_text='Select an optional image style.', verbose_name='style', blank=True, null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/djangocms_picture/models.py
+++ b/djangocms_picture/models.py
@@ -2,6 +2,7 @@ import os
 
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from cms.models import CMSPlugin, Page
@@ -28,6 +29,7 @@ class Picture(CMSPlugin):
                      (RIGHT, _("right")),
                      (CENTER, _("center")),
                      )
+    STYLE_CHOICES = getattr(settings, 'DJANGOCMS_PICTURE_STYLES', None)
 
     image = models.ImageField(_("image"), upload_to=get_plugin_media_path)
     url = models.CharField(
@@ -54,6 +56,10 @@ class Picture(CMSPlugin):
     float = models.CharField(
         _("side"), max_length=10, blank=True, null=True, choices=FLOAT_CHOICES,
         help_text=_("Move image left, right or center."))
+
+    style = models.CharField(
+        _("style"), max_length=255, blank=True, null=True, choices=STYLE_CHOICES,
+        help_text=_("Select an optional image style."))
 
     def __str__(self):
         if self.alt:


### PR DESCRIPTION
Proposal to fix #10 to unobtrusively add a style classname to a picture plugin. I've always felt that's the minimum to include for a plugin. Makes it a lot more useful and generic than it is now I think.

I've included django migrations. Not sure how to generate South migrations if that is still necessary. Can I convert a django migration to a South migration?