### PR TITLE
Allow showing the full image instead of an icon when embedding the plugin

### DIFF
--- a/djangocms_picture/cms_plugins.py
+++ b/djangocms_picture/cms_plugins.py
@@ -1,3 +1,4 @@
+import urlparse
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
@@ -31,6 +32,6 @@ class PicturePlugin(CMSPluginBase):
         if getattr(settings, 'PICTURE_FULL_IMAGE_AS_ICON', False):
             return instance.image.url
         else:
-            return settings.STATIC_URL + u"cms/img/icons/plugins/image.png"
+            return urlparse.urljoin(settings.STATIC_URL, u"cms/img/icons/plugins/image.png")
 
 plugin_pool.register_plugin(PicturePlugin)

--- a/djangocms_picture/cms_plugins.py
+++ b/djangocms_picture/cms_plugins.py
@@ -28,7 +28,9 @@ class PicturePlugin(CMSPluginBase):
         return context
 
     def icon_src(self, instance):
-        # TODO - possibly use 'instance' and provide a thumbnail image
-        return settings.STATIC_URL + u"cms/img/icons/plugins/image.png"
+        if getattr(settings, 'PICTURE_FULL_IMAGE_AS_ICON', False):
+            return instance.image.url
+        else:
+            return settings.STATIC_URL + u"cms/img/icons/plugins/image.png"
 
 plugin_pool.register_plugin(PicturePlugin)

--- a/djangocms_picture/tests/test_cms_plugins.py
+++ b/djangocms_picture/tests/test_cms_plugins.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+from django.conf import settings
+from django.test.utils import override_settings
+from mock import Mock, MagicMock
+from djangocms_picture.cms_plugins import PicturePlugin
+from djangocms_picture.models import Picture
+
+
+class PicturePluginTestCase(TestCase):
+
+    def test_plugin_returns_icon_by_default(self):
+        if hasattr(settings, 'PICTURE_FULL_IMAGE_AS_ICON'):
+            del settings.PICTURE_FULL_IMAGE_AS_ICON
+
+        picture_plugin = PicturePlugin()
+        mock_picture = Mock(spec=Picture)
+        self.assertEqual(settings.STATIC_URL + u"cms/img/icons/plugins/image.png", picture_plugin.icon_src(mock_picture))
+
+    @override_settings(PICTURE_FULL_IMAGE_AS_ICON=True)
+    def test_plugin_returns_full_image_if_set_in_settings(self):
+        picture_plugin = PicturePlugin()
+        mock_picture = MagicMock()
+        mock_picture.image = MagicMock()
+        image_url = '/path/to/full/image.png'
+        mock_picture.image.url = image_url
+        self.assertEqual(image_url, picture_plugin.icon_src(mock_picture))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 transifex-client
+mock==1.0.1


### PR DESCRIPTION
Enabled by setting the setting PICTURE_FULL_IMAGE_AS_ICON=True