### PR TITLE
adapted testing infrastructure, migrations and naming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ env:
   - TOX_ENV=py27-latest
   - TOX_ENV=py34-latest
   # Django 1.8
-  - TOX_ENV=py34-dj18-cms33
-  - TOX_ENV=py34-dj18-cms32
+  - TOX_ENV=py27-dj18-cms34
   - TOX_ENV=py27-dj18-cms33
-  - TOX_ENV=py27-dj18-cms32
+  - TOX_ENV=py34-dj18-cms34
+  - TOX_ENV=py34-dj18-cms33
   # Django 1.9
-  - TOX_ENV=py34-dj19-cms33
-  - TOX_ENV=py34-dj19-cms32
+  - TOX_ENV=py27-dj19-cms34
   - TOX_ENV=py27-dj19-cms33
-  - TOX_ENV=py27-dj19-cms32
+  - TOX_ENV=py34-dj19-cms34
+  - TOX_ENV=py34-dj19-cms33
 
 install:
   - pip install tox coverage

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@ Changelog
 =========
 
 
+2.0.4 (unreleased)
+==================
+
+* Prevent changes to ``DJANGOCMS_PICTURE_XXX`` settings from requiring new
+  migrations
+* Changed naming of ``Aldryn`` to ``Divio Cloud``
+* Adapted testing infrastructure (tox/travis) to incorporate
+  django CMS 3.4 and dropped 3.2
+
+
 2.0.3 (2016-10-31)
 ==================
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ django CMS Picture
 **django CMS Picture** is a plugin for `django CMS <http://django-cms.org>`_
 that allows you to add images on your site.
 
-This addon is compatible with `Aldryn <http://aldryn.com>`_ and is also available on the
+This addon is compatible with `Divio Cloud <http://divio.com>`_ and is also available on the
 `django CMS Marketplace <https://marketplace.django-cms.org/en/addons/browse/djangocms-picture/>`_
 for easy installation.
 

--- a/djangocms_picture/migrations/0004_adapt_fields.py
+++ b/djangocms_picture/migrations/0004_adapt_fields.py
@@ -6,6 +6,7 @@ import django.db.models.deletion
 import djangocms_attributes_field.fields
 import cms.models.fields
 import filer.fields.image
+from djangocms_picture.models import get_templates, LINK_TARGET
 
 
 class Migration(migrations.Migration):
@@ -33,7 +34,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='picture',
             name='link_target',
-            field=models.CharField(blank=True, max_length=255, verbose_name='Link target', choices=[('_blank', 'Open in new window'), ('_self', 'Open in same window'), ('_parent', 'Delegate to parent'), ('_top', 'Delegate to top')]),
+            field=models.CharField(blank=True, max_length=255, verbose_name='Link target', choices=LINK_TARGET),
         ),
         migrations.AddField(
             model_name='picture',
@@ -68,7 +69,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='picture',
             name='template',
-            field=models.CharField(default='default', max_length=255, verbose_name='Template', choices=[('default', 'Default')]),
+            field=models.CharField(default=get_templates()[0][0], max_length=255, verbose_name='Template', choices=get_templates()),
         ),
         migrations.RenameField(
             model_name='picture',

--- a/djangocms_picture/migrations/0007_fix_alignment.py
+++ b/djangocms_picture/migrations/0007_fix_alignment.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from djangocms_picture.models import PICTURE_ALIGNMENT
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('djangocms_picture', '0006_remove_null_values'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='picture',
+            name='alignment',
+            field=models.CharField(blank=True, help_text='Aligns the image according to the selected option.', max_length=255, verbose_name='Alignment', choices=PICTURE_ALIGNMENT),
+        ),
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 envlist =
     flake8
     py{34,27}-latest
-    py{34,27}-dj18-cms{33,32}
-    py{34,27}-dj19-cms{33,32}
+    py{34,27}-dj18-cms{34,33}
+    py{34,27}-dj19-cms{34,33}
 
 skip_missing_interpreters=True
 
@@ -14,8 +14,8 @@ deps =
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
     latest: django-cms
-    cms32: django-cms>=3.2,<3.3
     cms33: django-cms>=3.3,<3.4
+    cms34: django-cms>=3.4,<3.5
 commands =
     {envpython} --version
     {env:COMMAND:coverage} erase


### PR DESCRIPTION
* Prevent changes to ``DJANGOCMS_PICTURE_XXX`` settings from requiring new
  migrations
* Changed naming of ``Aldryn`` to ``Divio Cloud``
* Adapted testing infrastructure (tox/travis) to incorporate
  django CMS 3.4 and dropped 3.2
