### PR TITLE
Fix error if image is missing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,8 @@ Changelog
 * Changed naming of ``Aldryn`` to ``Divio Cloud``
 * Adapted testing infrastructure (tox/travis) to incorporate
   django CMS 3.4 and dropped 3.2
+* Fixed an issue when no image is set after deletion in django-filer
+  (on_delete=SET_NULL)
 
 
 2.0.3 (2016-10-31)

--- a/djangocms_picture/templates/djangocms_picture/default/picture.html
+++ b/djangocms_picture/templates/djangocms_picture/default/picture.html
@@ -17,7 +17,7 @@
         {{ instance.external_picture }}
     {% elif instance.use_no_cropping %}
         {{ instance.picture.url }}
-    {% else %}
+    {% elif instance.picture %}
         {% thumbnail instance.picture picture_size.size crop=picture_size.crop upscale=picture_size.upscale subject_location=instance.picture.subject_location as thumbnail %}
         {{ thumbnail.url }}
     {% endif %}{% endspaceless %}"


### PR DESCRIPTION
Previously there would be an exception if no image is assigned and also
none of the other image options is selected.
Although form validation prevents that state from occurring, it can 
still happen due to on_delete=SET_NULL on the FilerImageField. So if a
referenced file in django-filer is deleted, form validation is bypassed.