### PR TITLE
Release version 2.0.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.0.4 (unreleased)
+2.0.4 (2016-11-22)
 ==================
 
 * Prevent changes to ``DJANGOCMS_PICTURE_XXX`` settings from requiring new

--- a/djangocms_picture/__init__.py
+++ b/djangocms_picture/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.0.3'
+__version__ = '2.0.4'


### PR DESCRIPTION
* Prevent changes to ``DJANGOCMS_PICTURE_XXX`` settings from requiring new
  migrations
* Changed naming of ``Aldryn`` to ``Divio Cloud``
* Adapted testing infrastructure (tox/travis) to incorporate
  django CMS 3.4 and dropped 3.2
* Fixed an issue when no image is set after deletion in django-filer
  (on_delete=SET_NULL)
* Updated translations