### PR TITLE
Correct link to MDN's docs on the HTML img element

### DIFF
--- a/djangocms_picture/templates/djangocms_picture/default/picture.html
+++ b/djangocms_picture/templates/djangocms_picture/default/picture.html
@@ -39,7 +39,7 @@
 {% endif %}
 
 {% comment %}
-    # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/image
+    # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img
     # https://developer.mozilla.org/en-US/docs/Web/HTML/Element/figure
     # https://github.com/divio/django-filer/blob/master/filer/models/imagemodels.py
     # http://easy-thumbnails.readthedocs.io/en/2.1/usage/#templates


### PR DESCRIPTION
This file's comment section currently links to the MDN documentation page for the HTML image element. This element is not only non-standard and should not be used, but isn't actually used in the code itself. I changed the link to the MDN documentation page for the HTML img element. A simple, quick change to avoid any confusion for anyone trying to see how the code works.