### PR TITLE
Release version to 2.0.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.0.6 (unreleased)
+2.0.6 (2017-10-12)
 ==================
 
 * Fixed a misleading link to MDN inside code documentation

--- a/djangocms_picture/__init__.py
+++ b/djangocms_picture/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.0.5'
+__version__ = '2.0.6'


### PR DESCRIPTION
* Fixed a misleading link to MDN inside code documentation
* Abstract the link model so it can be extended by other addons