### PR TITLE
initial Django 2.0 support

### DIFF
--- a/djangocms_picture/migrations/0001_initial.py
+++ b/djangocms_picture/migrations/0001_initial.py
@@ -15,13 +15,13 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Picture',
             fields=[
-                ('cmsplugin_ptr', models.OneToOneField(serialize=False, parent_link=True, auto_created=True, to='cms.CMSPlugin', primary_key=True)),
+                ('cmsplugin_ptr', models.OneToOneField(serialize=False, parent_link=True, auto_created=True, to='cms.CMSPlugin', primary_key=True, on_delete=models.CASCADE)),
                 ('image', models.ImageField(verbose_name='image', upload_to=cms.models.pluginmodel.get_plugin_media_path)),
                 ('url', models.CharField(help_text='If present, clicking on image will take user to link.', blank=True, null=True, max_length=255, verbose_name='link')),
                 ('alt', models.CharField(help_text='Specifies an alternate text for an image, if the imagecannot be displayed.<br />Is also used by search enginesto classify the image.', blank=True, null=True, max_length=255, verbose_name='alternate text')),
                 ('longdesc', models.CharField(help_text='When user hovers above picture, this text will appear in a popup.', blank=True, null=True, max_length=255, verbose_name='long description')),
                 ('float', models.CharField(help_text='Move image left, right or center.', blank=True, max_length=10, choices=[('left', 'left'), ('right', 'right'), ('center', 'center')], verbose_name='side', null=True)),
-                ('page_link', models.ForeignKey(help_text='If present, clicking on image will take user to specified page.', blank=True, verbose_name='page', to='cms.Page', null=True)),
+                ('page_link', models.ForeignKey(help_text='If present, clicking on image will take user to specified page.', blank=True, verbose_name='page', to='cms.Page', null=True, on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,

--- a/djangocms_picture/migrations/0003_migrate_to_filer.py
+++ b/djangocms_picture/migrations/0003_migrate_to_filer.py
@@ -41,7 +41,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='picture',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='djangocms_picture_picture', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='djangocms_picture_picture', auto_created=True, primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
         migrations.RunPython(migrate_to_filer),
         migrations.RemoveField(

--- a/djangocms_picture/migrations/0004_adapt_fields.py
+++ b/djangocms_picture/migrations/0004_adapt_fields.py
@@ -59,7 +59,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='picture',
             name='thumbnail_options',
-            field=models.ForeignKey(blank=True, to='filer.ThumbnailOption', help_text='Overrides width, height, and crop; scales up to the provided preset dimensions.', null=True, verbose_name='Thumbnail options'),
+            field=models.ForeignKey(blank=True, to='filer.ThumbnailOption', help_text='Overrides width, height, and crop; scales up to the provided preset dimensions.', null=True, verbose_name='Thumbnail options', on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name='picture',
@@ -109,6 +109,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='picture',
             name='cmsplugin_ptr',
-            field=models.OneToOneField(parent_link=True, related_name='djangocms_picture_picture', primary_key=True, serialize=False, to='cms.CMSPlugin'),
+            field=models.OneToOneField(parent_link=True, related_name='djangocms_picture_picture', primary_key=True, serialize=False, to='cms.CMSPlugin', on_delete=models.CASCADE),
         ),
     ]

--- a/djangocms_picture/models.py
+++ b/djangocms_picture/models.py
@@ -172,6 +172,7 @@ class AbstractPicture(CMSPlugin):
         blank=True,
         null=True,
         help_text=_('Overrides width, height, and crop; scales up to the provided preset dimensions.'),
+        on_delete=models.CASCADE,
     )
 
     # Add an app namespace to related_name to avoid field name clashes
@@ -182,6 +183,7 @@ class AbstractPicture(CMSPlugin):
         CMSPlugin,
         related_name='%(app_label)s_%(class)s',
         parent_link=True,
+        on_delete=models.CASCADE,
     )
 
     class Meta:


### PR DESCRIPTION
Squashing some incompatibilities between Django 1.11 and 2.0.

django-cms is not Django 2.0 ready yet, but I'm trying to get various plugins and dependencies compatible to make it easier for the whole ecosystem to work on 2.0.x eventually.