### PR TITLE
Fix swappable filer image model support

### DIFF
--- a/djangocms_picture/migrations/0003_migrate_to_filer.py
+++ b/djangocms_picture/migrations/0003_migrate_to_filer.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
 import filer.fields.image
+from filer.utils.loader import load_model
 
 
 def migrate_to_filer(apps, schema_editor):
     # Because filer is polymorphic, Djangos migration can't handle
-    from filer.models import Image
+    Image = load_model(settings.FILER_IMAGE_MODEL)
     Picture = apps.get_model('djangocms_picture', 'Picture')
     plugins = Picture.objects.all()
 
@@ -28,6 +30,7 @@ def migrate_to_filer(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
+        migrations.swappable_dependency(settings.FILER_IMAGE_MODEL),
         ('filer', '0006_auto_20160623_1627'),
         ('djangocms_picture', '0002_auto_20151018_1927'),
     ]
@@ -36,7 +39,8 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='picture',
             name='picture',
-            field=filer.fields.image.FilerImageField(related_name='+', on_delete=django.db.models.deletion.SET_NULL, verbose_name='Picture', blank=True, to='filer.Image', null=True),
+            field=filer.fields.image.FilerImageField(related_name='+', on_delete=django.db.models.deletion.SET_NULL,
+                                                     verbose_name='Picture', blank=True, to=settings.FILER_IMAGE_MODEL, null=True),
         ),
         migrations.AlterField(
             model_name='picture',

--- a/djangocms_picture/migrations/0004_adapt_fields.py
+++ b/djangocms_picture/migrations/0004_adapt_fields.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.db import migrations, models
 import django.db.models.deletion
 import djangocms_attributes_field.fields
@@ -104,7 +105,8 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='picture',
             name='picture',
-            field=filer.fields.image.FilerImageField(related_name='+', on_delete=django.db.models.deletion.SET_NULL, verbose_name='Image', blank=True, to='filer.Image', null=True),
+            field=filer.fields.image.FilerImageField(related_name='+', on_delete=django.db.models.deletion.SET_NULL,
+                                                     verbose_name='Image', blank=True, to=settings.FILER_IMAGE_MODEL, null=True),
         ),
         migrations.AlterField(
             model_name='picture',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from djangocms_picture import __version__
 
 REQUIREMENTS = [
     'django-cms>=3.2.0',
-    'django-filer>=1.2.4',
+    'django-filer>=1.3.0',
     'djangocms-attributes-field>=0.1.1',
 ]
 


### PR DESCRIPTION
As of filer 1.3.0, proper swappable image model support is available. This PR makes it possible to use djangocms-picture with swapped image model.