### PR TITLE
Release for 2.1.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.1.2 (2018-12-05)
+2.1.2 (2018-12-06)
 ==================
 
 * Fixed an issue creating a validation error on the alt attribute

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.1.2 (unreleased)
+2.1.2 (2018-12-05)
 ==================
 
 * Fixed an issue creating a validation error on the alt attribute

--- a/djangocms_picture/__init__.py
+++ b/djangocms_picture/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.1.1'
+__version__ = '2.1.2'


### PR DESCRIPTION
* Fixed an issue creating a validation error on the alt attribute
* Fixed an issue in the template adding a ``}`` after the ``srcset``
* Adapted test matrix for django CMS 3.4, 3.5, 3.6 as well as
  Django 1.11, 2.0 and 2.1
* Exclude ``tests`` folder from release build