### PR TITLE
Convert breakpoints to integers

### DIFF
--- a/djangocms_picture/cms_plugins.py
+++ b/djangocms_picture/cms_plugins.py
@@ -69,8 +69,8 @@ class PicturePlugin(CMSPluginBase):
         # assign link to a context variable to be performant
         context['picture_link'] = instance.get_link()
         context['picture_size'] = instance.get_size(
-            width=float(context.get('width') or 0),
-            height=float(context.get('height') or 0),
+            width=context.get('width') or 0,
+            height=context.get('height') or 0,
         )
         context['img_srcset_data'] = instance.img_srcset_data
 

--- a/djangocms_picture/models.py
+++ b/djangocms_picture/models.py
@@ -344,7 +344,7 @@ class AbstractPicture(CMSPlugin):
 
         for size in filter(lambda x: x < picture_width, breakpoints):
             thumbnail_options['size'] = (size, size)
-            srcset.append((size, thumbnailer.get_thumbnail(thumbnail_options)))
+            srcset.append((int(size), thumbnailer.get_thumbnail(thumbnail_options)))
 
         return srcset
 

--- a/djangocms_picture/models.py
+++ b/djangocms_picture/models.py
@@ -358,8 +358,8 @@ class AbstractPicture(CMSPlugin):
             return self.picture.url
 
         picture_options = self.get_size(
-            width=float(self.width or 0),
-            height=float(self.height or 0),
+            width=self.width or 0,
+            height=self.height or 0,
         )
 
         thumbnail_options = {


### PR DESCRIPTION
Based on the locale it can happen, that the decimal separator is a comma, which causes issues generating the source set. E.g. `576,0w`

The following was previously generated on my system:
```html
<img src="/media/filer_public_thumbnails/filer_public/95/20/95201025-d9b4-4c83-84f9-e7a41a2c8718/do-it-2.jpg__1920x768_q90_subsampling-2.jpg" alt="" 
srcset="/media/filer_public_thumbnails/filer_public/95/20/95201025-d9b4-4c83-84f9-e7a41a2c8718/do-it-2.jpg__576.0x576.0_q90_subsampling-2.jpg 576,0w,
        /media/filer_public_thumbnails/filer_public/95/20/95201025-d9b4-4c83-84f9-e7a41a2c8718/do-it-2.jpg__768.0x768.0_q90_subsampling-2.jpg 768,0w,
        /media/filer_public_thumbnails/filer_public/95/20/95201025-d9b4-4c83-84f9-e7a41a2c8718/do-it-2.jpg__992.0x992.0_q90_subsampling-2.jpg 992,0w,
        /media/filer_public_thumbnails/filer_public/95/20/95201025-d9b4-4c83-84f9-e7a41a2c8718/do-it-2.jpg__1200.0x1200.0_q90_subsampling-2.jpg 1200,0w,
        /media/filer_public_thumbnails/filer_public/95/20/95201025-d9b4-4c83-84f9-e7a41a2c8718/do-it-2.jpg__1920x768_q90_subsampling-2.jpg 1920w" 
sizes="
(max-width: 576,0px) 576,0px,
(max-width: 768,0px) 768,0px,
(max-width: 992,0px) 992,0px,
(max-width: 1200,0px) 1200,0px,
1920px " 
class="img-fluid cms-plugin cms-plugin-1338">
```