### PR TITLE
Check if internal picture is used before creating srcset (ref #69)

### DIFF
--- a/djangocms_picture/models.py
+++ b/djangocms_picture/models.py
@@ -328,7 +328,10 @@ class AbstractPicture(CMSPlugin):
 
     @property
     def img_srcset_data(self):
-        if not self.is_responsive_image:
+        # external picture takes priority by design
+        if self.external_picture:
+            return None
+        elif not (self.is_responsive_image and self.picture):
             return None
 
         srcset = []


### PR DESCRIPTION
This prevents easy_thumbnails throwing an exception if a plugin's srcset is called without an internal picture being set (because an external image was set instead, or the picture was deleted in Filer's backend).