### PR TITLE
Bumped version to 2.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.3.0 (2019-07-04)
+2.3.0 (2019-07-09)
 ==================
 
 * Fixes an issue where ``get_link`` doesn't return external picture

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.3.0 (unreleased)
+2.3.0 (2019-07-04)
 ==================
 
 * Fixes an issue where ``get_link`` doesn't return external picture

--- a/djangocms_picture/__init__.py
+++ b/djangocms_picture/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.2.1'
+__version__ = '2.3.0'


### PR DESCRIPTION
* Fixes an issue where ``get_link`` doesn't return external picture
* Fixes ``img_srcset_data`` being processed on an external picture
* Added tests for the plugin itself
* Updated translations
