### PR TITLE
Fixed alt attribute not rendering correctly

### DIFF
--- a/djangocms_picture/templates/djangocms_picture/default/picture.html
+++ b/djangocms_picture/templates/djangocms_picture/default/picture.html
@@ -14,9 +14,7 @@
 
 
 <img src="{{ instance.img_src }}"
-    alt="{% if instance.attributes.alt %}{{ instance.attributes.alt }}
-         {% elif instance.picture.default_alt_text %}
-         {{ instance.picture.default_alt_text }}{% endif %}"
+    alt="{% if instance.attributes.alt %}{{ instance.attributes.alt }}{% elif instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% endif %}"
     {% if instance.width %} width="{{ instance.width }}"{% endif %}
     {% if instance.height %} height="{{ instance.height }}"{% endif %}
     {% if img_srcset_data %}

--- a/djangocms_picture/templates/djangocms_picture/default/picture.html
+++ b/djangocms_picture/templates/djangocms_picture/default/picture.html
@@ -14,7 +14,9 @@
 
 
 <img src="{{ instance.img_src }}"
-    alt="{% if instance.picture.default_alt_text and not instance.attributes.alt %}{{ instance.picture.default_alt_text }}{% endif %}"
+    alt="{% if instance.attributes.alt %}{{ instance.attributes.alt }}
+         {% elif instance.picture.default_alt_text %}
+         {{ instance.picture.default_alt_text }}{% endif %}"
     {% if instance.width %} width="{{ instance.width }}"{% endif %}
     {% if instance.height %} height="{{ instance.height }}"{% endif %}
     {% if img_srcset_data %}


### PR DESCRIPTION
Giving alt text as a plugin attribute results in the image having two alt tags (the first one from the template and the second one from the variable "attributes_str"). Html only allows one alt attribute per <img> tag, resulting in the first (empty) alt attribute overriding the latter.

This fix allows the plugin attribute "alt" to render in the initial alt tag. Fallback to picture.default_alt_text is preserved.