### PR TITLE
Bumped version to 2.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Changelog
 =========
 
 
-2.4.0 (unreleased)
+2.4.0 (2020-01-29)
 ==================
 
 * Added support for Django 3.0

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ file for additional dependencies:
 
 * Django Filer 1.5.0 or higher
 
-Make sure `django Filer <http://django-filer.readthedocs.io/en/latest/installation.html>`_
+Make sure `django-filer <http://django-filer.readthedocs.io/en/latest/installation.html>`_
 is installed and configured appropriately.
 
 

--- a/djangocms_picture/__init__.py
+++ b/djangocms_picture/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.3.0'
+__version__ = '2.4.0'


### PR DESCRIPTION
* Added support for Django 3.0
* Pinned ``django-filer`` to 1.5.0
* Added further tests to raise coverage
* Fixed smaller issues found during testing
* Dropped support for django-filer <= 1.4
* Fixed alt attribute not rendering correctly